### PR TITLE
Known only to force +r

### DIFF
--- a/chanserv/chancmds/chanflags.c
+++ b/chanserv/chancmds/chanflags.c
@@ -126,6 +126,14 @@ int csc_dochanflags(void *source, int cargc, char **cargv) {
         cs_checkchanmodes(cip->channel);
     }
 
+    /* Handle known only to force registered only mode */
+    if (CIsKnownOnly(rcp) && !(oldflags & QCFLAG_KNOWNONLY)) {
+      rcp->forcemodes |= CHANMODE_REGONLY;
+      rcp->denymodes &= ~CHANMODE_REGONLY;
+      if (cip->channel)
+        cs_checkchanmodes(cip->channel);
+    }
+
     /* If nothing has changed, say so and don't do anything else */
     if (rcp->flags == oldflags) {
       chanservstdmessage(sender, QM_CHANLEVNOCHANGE);

--- a/chanserv/chancmds/chanmode.c
+++ b/chanserv/chancmds/chanmode.c
@@ -172,6 +172,12 @@ int csc_dochanmode(void *source, int cargc, char **cargv) {
       forceflags &= ~CHANMODE_LIMIT;
     }
 
+    /* Check if chanflag +k is set and if so preserve the registered only */
+    if (CIsKnownOnly(rcp)) {
+      forceflags |= CHANMODE_REGONLY;
+      denyflags &= ~CHANMODE_REGONLY;
+    }
+
     /* It parsed OK, so update the structure.. */
     rcp->forcemodes=forceflags;
     rcp->denymodes=denyflags;      


### PR DESCRIPTION
This change makes sure then when known only mode is set, only registered users may join the channel, to avoid them being banned upon first join if not registered.