### PR TITLE
fix an issue where the trust logger would show the ID and the trust limit the wrong way round

### DIFF
--- a/helpmod2/hcommands.c
+++ b/helpmod2/hcommands.c
@@ -2386,7 +2386,7 @@ static void helpmod_cmd_ticket (huser *sender, channel* returntype, char* ostr, 
         helpmod_reply(sender, returntype, "Cannot issue a ticket: User %s is considered improper and not worthy of a ticket", argv[1]);
         return;
     }
-    if (huser_get_level(husr) > H_PEON)
+    if (huser_get_level(husr) > H_FRIEND)
     {
         helpmod_reply(sender, returntype, "Cannot issue a ticket: User %s does not require a ticket", argv[1]);
         return;

--- a/trusts/trusts_management.c
+++ b/trusts/trusts_management.c
@@ -207,7 +207,7 @@ static int trusts_cmdtrustgroupadd(void *source, int cargc, char **cargv) {
   controlwall(NO_OPER, NL_TRUSTS, "%s TRUSTGROUPADD'ed '%s'", controlid(sender), tg->name->content);
   trustlog(tg, sender->authname, "Created trust group '%s' (ID #%d): howmany=%d, enforceident=%d, maxperident=%d, "
     "createdby=%s, contact=%s, comment=%s",
-    tg->name->content, howmany, tg->id, enforceident, maxperident, createdby, contact, comment);
+    tg->name->content, tg->id, howmany, enforceident, maxperident, createdby, contact, comment);
 
   return CMD_OK;
 }


### PR DESCRIPTION
[(https://github.com/quakenet/newserv/issues/35)]