### PR TITLE
CHANSERV: listflags fixes

### DIFF
--- a/chanserv/chanserv_messages.h
+++ b/chanserv/chanserv_messages.h
@@ -153,7 +153,7 @@ BeginMessages() {
   msg(QM_TOOMANYRESULTS, "Found over $0 $1, truncating list.", "ds"),
   msg(QM_RESULTCOUNT, "Found $0 $1$2.", "uss"),
   msg(QM_SUSPENDKILL, "Attention: Your Q account has been suspended. You are being disconnected.", ""),
-  msg(QM_LISTFLAGSHEADER, "Username:       Flags:            Suspended: Email:                         Last user@host:", ""),
+  msg(QM_LISTFLAGSHEADER, "Username:       Flags:            Email:                         Last email change:", ""),
   msg(QM_SUSPENDUSERLISTHEADER, "Username:       Suspend type: Suspended by:   Date suspended:     Expires:        Reason:", ""), /* @TIMELEN */
   msg(QM_SUSPENDCHANLISTHEADER, "Channel:                       Suspended by:   Date suspended:     Reason:", ""), /* @TIMELEN */
   msg(QM_NOREQUESTOWNER, "You cannot request ownership of $0 as there is a channel $1 present.", "ss"),

--- a/chanserv/usercmds/listflags.c
+++ b/chanserv/usercmds/listflags.c
@@ -43,14 +43,33 @@ int csu_dolistflags(void *source, int cargc, char **cargv) {
       }
     }
   }
-  
+
+  if (!matchflags || (matchflags == QUFLAG_NOTICE)) {
+    chanservsendmessage(sender, "Error: no flags selected");
+    return CMD_ERROR;
+  }
+
   chanservstdmessage(sender, QM_LISTFLAGSHEADER);
   for (i=0;i<REGUSERHASHSIZE;i++) {
     for (dbrup=regusernicktable[i]; dbrup; dbrup=dbrup->nextbyname) {
       if ((dbrup->flags & matchflags) == matchflags) {
-        chanservsendmessage(sender, "%-15s %-17s %-10s %-30s %s", dbrup->username, printflags(dbrup->flags, ruflags), 
-          UHasSuspension(dbrup)?"yes":"no", dbrup->email?dbrup->email->content:"none set", 
-          dbrup->lastuserhost?dbrup->lastuserhost->content:"none");
+        char tbuf[TIMELEN], *tdata;
+
+        if (dbrup->lastemailchange) {
+          q9strftime(tbuf, sizeof(tbuf), dbrup->lastemailchange);
+          tdata = tbuf;
+        } else {
+          tdata = "(none)";
+        }
+
+        char *email;
+        if (dbrup->email && dbrup->email->content[0]) {
+          email = dbrup->email->content;
+        } else {
+          email = "(none)";
+        }
+
+        chanservsendmessage(sender, " %-15s %-17s %-30s %-15s", dbrup->username, printflags(dbrup->flags, ruflags), email, tdata);
         count++;
         if (count >= 2000) {
           chanservstdmessage(sender, QM_TOOMANYRESULTS, 2000, "users");


### PR DESCRIPTION
- output now contains last email change
- suspended/last host removed
- output fixed for no email
- output now easier to parse
- + / +n prohibited